### PR TITLE
BUGFIX: mass notification email processor

### DIFF
--- a/src/Oro/Bundle/NotificationBundle/Async/SendMassEmailMessageProcessor.php
+++ b/src/Oro/Bundle/NotificationBundle/Async/SendMassEmailMessageProcessor.php
@@ -94,7 +94,7 @@ class SendMassEmailMessageProcessor implements MessageProcessorInterface, TopicS
         ], $data);
 
         if (empty($data['body'])
-            || !isset($data['fromEmail'], $data['toEmail'])
+            || !isset($data['sender'], $data['toEmail'])
             || (isset($data['template']) && !is_array($data['body']))
         ) {
             $this->logger->critical('Got invalid message');


### PR DESCRIPTION
Fix an issue with a missing parameter "sender", replaced to "fromEmail" as non existing in body message